### PR TITLE
Fix game orientation

### DIFF
--- a/finger-paint/app/src/main/java/ru/cscenter/fingerpaint/ui/games/base/BaseGameActivity.kt
+++ b/finger-paint/app/src/main/java/ru/cscenter/fingerpaint/ui/games/base/BaseGameActivity.kt
@@ -1,5 +1,7 @@
 package ru.cscenter.fingerpaint.ui.games.base
 
+import android.content.pm.ActivityInfo
+import android.content.res.Configuration
 import android.os.Bundle
 import androidx.appcompat.app.AppCompatActivity
 import androidx.fragment.app.Fragment
@@ -10,7 +12,17 @@ abstract class BaseGameActivity : AppCompatActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         setContentView(R.layout.activity_game)
+        lockOrientation()
         startGame()
+    }
+
+    private fun lockOrientation() {
+        val currentOrientation = resources.configuration.orientation
+        requestedOrientation = if (currentOrientation == Configuration.ORIENTATION_LANDSCAPE) {
+            ActivityInfo.SCREEN_ORIENTATION_SENSOR_LANDSCAPE
+        } else {
+            ActivityInfo.SCREEN_ORIENTATION_SENSOR_PORTRAIT
+        }
     }
 
     fun startGame() = runGame(firstGame().getGame())


### PR DESCRIPTION
Сейчас в играх можно выбрать любую ориентацию заранее, но если в процессе игры сменить ориентацию экрана, то приложение упадет. В данном решении запрещается менять ориентацию во время игры.